### PR TITLE
SEO-Tag in HEAD eingebunden

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,10 +3,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     
-    <!-- SEO Meta Tags -->
-    <title>{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
-    <meta name="author" content="{{ site.author }}">
+    <!-- SEO Meta Tags (jekyll-seo-tag) -->
+    {% seo %}
     
     <!-- Preload Critical Resources -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
Das SEO-Tag-Modul für Jekyll war zwar korrekt eingebunden, wurde aber noch nicht korrekt in den Templates genutzt. Ich habe die manuelle Implementierung der Metadaten durch die Einbindung des Plugins ersetzt.