### PR TITLE
Funktion für Eventrückblicke als Beitrag hinzugefügt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,83 @@ For embedding event registration forms directly in blog posts:
 - `voucher`: Pre-fill voucher code (optional)
 - `disable-vouchers`: Set to "true" to hide voucher input (optional)
 
+### Linking Event Announcements and Retrospectives
+
+**New as of October 2025:** Event announcements and retrospectives can be elegantly linked without cluttering the blog overview!
+
+#### Workflow:
+
+**1. Create Event Announcement:**
+Create a regular blog post for the event announcement in `_beitraege/`:
+```markdown
+---
+title: "KI Workshop for Associations"
+teaser: "Learn how AI can support your association work"
+author: "Sarah Mueller"
+category: "Events"
+date: 2025-08-15
+---
+
+Event details, registration form, etc.
+```
+
+**2. After Event: Create Retrospective:**
+Create a new post with "-rueckschau" suffix:
+```markdown
+---
+title: "KI Workshop for Associations - Retrospective"
+teaser: "An inspiring evening with many practical insights"
+author: "Sarah Mueller"
+category: "Events"
+date: 2025-08-20
+related_post: "ki-workshop-vereine"
+is_retrospective: true
+---
+
+Event recap, photos, summary, etc.
+```
+
+**3. Link Posts Together:**
+Add to the **original announcement post**:
+```yaml
+retrospective_post: "ki-workshop-vereine-rueckschau"
+```
+
+#### Key Parameters:
+
+- **`is_retrospective: true`**: Marks post as retrospective
+  - Retrospectives are **filtered out** from `/beitraege/` overview page
+  - Accessible via banner link or direct URL only
+
+- **`related_post: "filename"`**: Links back to announcement
+  - Automatically displays "📅 Event Announcement" banner with link
+
+- **`retrospective_post: "filename"`**: Links to retrospective
+  - Automatically displays "📸 Event Retrospective Available" banner with link
+
+#### Implementation Details:
+
+**Banner Component:** `_includes/related-post-banner.html`
+- Automatically included in `_layouts/post.html`
+- Bidirectional linking with visual banners
+- Responsive design with slide-in animation
+- Different color schemes for announcement vs. retrospective
+
+**Filtering:** `beitraege.html`
+```liquid
+{% for beitrag in sorted_beitraege %}
+{% unless beitrag.is_retrospective %}
+  <!-- Only show non-retrospective posts -->
+{% endunless %}
+{% endfor %}
+```
+
+**Benefits:**
+- Clean blog overview (only announcements visible)
+- No lost content (retrospectives accessible via links)
+- Automatic visual connection between related posts
+- Optional system (only use when needed)
+
 ### Styling Considerations
 - **Background color detection**: Navigation automatically adapts to section backgrounds
 - **Animation delays**: Use consistent staggered timing (0.1s, 0.2s, 0.3s increments)

--- a/REDAKTIONSLEITFADEN.md
+++ b/REDAKTIONSLEITFADEN.md
@@ -138,6 +138,106 @@ Weiterer Text...
 ### Praktischer Tipp:
 **Vorlage kopieren:** Öffne `_beitraege/diese-website-wurde-mit-ki-erstellt.md`, kopiere den Inhalt und passe ihn für deinen neuen Beitrag an.
 
+### Event-Ankündigungen und Rückschauen verknüpfen
+
+**Neu seit Oktober 2025:** Du kannst Event-Ankündigungen und Rückschauen elegant miteinander verknüpfen, ohne die Beitragsübersicht zu überladen!
+
+#### Workflow für Event-Beiträge:
+
+**1. Event-Ankündigung erstellen:**
+Erstelle wie gewohnt einen Beitrag zur Event-Ankündigung:
+```markdown
+---
+title: "KI Workshop für Vereine"
+teaser: "Lerne, wie KI deine Vereinsarbeit unterstützen kann"
+author: "Sarah Mueller"
+category: "Events"
+date: 2025-08-15
+---
+
+Details zum Event, Anmeldeformular, etc.
+```
+
+**2. Nach dem Event: Rückschau erstellen:**
+Erstelle einen neuen Beitrag mit dem Suffix "-rueckschau":
+```markdown
+---
+title: "KI Workshop für Vereine - Rückschau"
+teaser: "Ein inspirierender Abend mit vielen praktischen Einblicken"
+author: "Sarah Mueller"
+category: "Events"
+date: 2025-08-20
+related_post: "ki-workshop-vereine"
+is_retrospective: true
+---
+
+Rückblick auf das Event, Bilder, Zusammenfassung, etc.
+```
+
+**3. Verknüpfung herstellen:**
+Füge im **Original-Beitrag** (Ankündigung) folgende Zeile hinzu:
+```yaml
+retrospective_post: "ki-workshop-vereine-rueckschau"
+```
+
+#### Wichtige Parameter:
+
+- **`is_retrospective: true`**: Markiert den Beitrag als Rückschau
+  - Rückschauen erscheinen **nicht** in der Beitragsübersicht `/beitraege/`
+  - Sie sind nur über die Verlinkung oder direkte URL erreichbar
+
+- **`related_post: "dateiname"`**: Verlinkt zurück zur Ankündigung
+  - Zeigt automatisch ein Banner "📅 Event-Ankündigung" mit Link
+
+- **`retrospective_post: "dateiname"`**: Verlinkt zur Rückschau
+  - Zeigt automatisch ein Banner "📸 Event-Rückschau verfügbar" mit Link
+
+#### Vollständiges Beispiel:
+
+**Event-Ankündigung** (`ki-workshop-vereine.md`):
+```markdown
+---
+title: "KI Workshop für Vereine"
+teaser: "Lerne, wie KI deine Vereinsarbeit unterstützen kann"
+author: "Sarah Mueller"
+category: "Events"
+date: 2025-08-15
+retrospective_post: "ki-workshop-vereine-rueckschau"
+---
+
+## Workshop Details
+Am 15. August veranstalten wir...
+
+{% include pretix-widget.html event="ki-workshop" %}
+```
+
+**Event-Rückschau** (`ki-workshop-vereine-rueckschau.md`):
+```markdown
+---
+title: "KI Workshop für Vereine - Rückschau"
+teaser: "Ein inspirierender Abend mit vielen praktischen Einblicken"
+author: "Sarah Mueller"
+category: "Events"
+date: 2025-08-20
+related_post: "ki-workshop-vereine"
+is_retrospective: true
+---
+
+## Highlights des Abends
+Der Workshop war ein voller Erfolg...
+
+{% include gallery.html
+   images="workshop1.jpg|Teilnehmende bei der Arbeit,workshop2.jpg|Präsentation der Ergebnisse"
+   folder="/assets/images/events/ki-workshop/" %}
+```
+
+#### Vorteile:
+
+✅ **Übersichtliche Beitragsseite**: Nur Ankündigungen erscheinen in der Liste
+✅ **Keine verlorenen Inhalte**: Rückschauen sind über Banner und URL erreichbar
+✅ **Automatische Banner**: Bidirektionale Verlinkung wird automatisch angezeigt
+✅ **Flexibel**: Du entscheidest, für welche Events du Rückschauen erstellst
+
 ## Markdown Grundlagen
 
 Markdown ist eine einfache Formatierungssprache:

--- a/_includes/related-post-banner.html
+++ b/_includes/related-post-banner.html
@@ -1,0 +1,28 @@
+<!-- Banner for linking announcement and retrospective posts -->
+{% if page.retrospective_post %}
+  <!-- Show banner linking to retrospective -->
+  {% assign retro_post = site.beitraege | where_exp: "item", "item.url contains page.retrospective_post" | first %}
+  {% if retro_post %}
+  <div class="related-post-banner retrospective-available">
+    <div class="banner-icon">📸</div>
+    <div class="banner-content">
+      <strong>Event-Rückschau verfügbar</strong>
+      <p>Das Event hat stattgefunden! Schau dir Eindrücke, Bilder und eine Zusammenfassung an.</p>
+    </div>
+    <a href="{{ retro_post.url | relative_url }}" class="banner-button">Zur Rückschau</a>
+  </div>
+  {% endif %}
+{% elsif page.related_post %}
+  <!-- Show banner linking back to announcement -->
+  {% assign announcement_post = site.beitraege | where_exp: "item", "item.url contains page.related_post" | first %}
+  {% if announcement_post %}
+  <div class="related-post-banner announcement-link">
+    <div class="banner-icon">📅</div>
+    <div class="banner-content">
+      <strong>Event-Ankündigung</strong>
+      <p>Hier findest du alle Details zum Event, Programm und Informationen.</p>
+    </div>
+    <a href="{{ announcement_post.url | relative_url }}" class="banner-button">Zur Ankündigung</a>
+  </div>
+  {% endif %}
+{% endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -67,6 +67,9 @@ layout: default
 <main class="post-content">
     <div class="container">
         <div class="content-wrapper">
+            <!-- Related Post Banner -->
+            {% include related-post-banner.html %}
+
             <article class="post-article">
                 {{ content }}
             </article>
@@ -325,6 +328,90 @@ layout: default
     border-radius: 2px;
 }
 
+/* Related Post Banner */
+.related-post-banner {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 1.5rem 2rem;
+    margin-bottom: 3rem;
+    border-radius: 12px;
+    box-shadow: var(--shadow-medium);
+    animation: slideIn 0.5s ease-out;
+}
+
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.related-post-banner.retrospective-available {
+    background: linear-gradient(135deg, #e8f8f9 0%, #f0f4ff 100%);
+    border-left: 4px solid var(--primary-turquoise);
+}
+
+.related-post-banner.announcement-link {
+    background: linear-gradient(135deg, #fff9e6 0%, #f0f4ff 100%);
+    border-left: 4px solid var(--primary-yellow);
+}
+
+.related-post-banner .banner-icon {
+    font-size: 3rem;
+    flex-shrink: 0;
+    line-height: 1;
+}
+
+.related-post-banner .banner-content {
+    flex: 1;
+}
+
+.related-post-banner .banner-content strong {
+    display: block;
+    font-size: 1.2rem;
+    color: var(--text-dark);
+    margin-bottom: 0.5rem;
+}
+
+.related-post-banner .banner-content p {
+    margin: 0;
+    color: var(--text-light);
+    font-size: 0.95rem;
+}
+
+.related-post-banner .banner-button {
+    flex-shrink: 0;
+    background: var(--primary-turquoise);
+    color: white;
+    padding: 0.8rem 1.5rem;
+    border-radius: 25px;
+    text-decoration: none;
+    font-weight: 600;
+    transition: all 0.3s ease;
+    box-shadow: 0 2px 8px rgba(0, 178, 187, 0.3);
+}
+
+.related-post-banner .banner-button:hover {
+    background: var(--secondary-blue);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(102, 108, 222, 0.4);
+}
+
+.related-post-banner.announcement-link .banner-button {
+    background: var(--secondary-blue);
+    box-shadow: 0 2px 8px rgba(102, 108, 222, 0.3);
+}
+
+.related-post-banner.announcement-link .banner-button:hover {
+    background: var(--primary-turquoise);
+    box-shadow: 0 4px 12px rgba(0, 178, 187, 0.4);
+}
+
 /* Author Section */
 .post-author {
     margin-top: 4rem;
@@ -574,6 +661,26 @@ layout: default
     .post-meta {
         flex-direction: column;
         gap: 0.5rem;
+    }
+
+    .related-post-banner {
+        flex-direction: column;
+        text-align: center;
+        padding: 1.5rem;
+        gap: 1rem;
+    }
+
+    .related-post-banner .banner-icon {
+        font-size: 2.5rem;
+    }
+
+    .related-post-banner .banner-content strong {
+        font-size: 1.1rem;
+    }
+
+    .related-post-banner .banner-button {
+        width: 100%;
+        padding: 0.9rem 1.5rem;
     }
 }
 </style>

--- a/beitraege.html
+++ b/beitraege.html
@@ -54,10 +54,11 @@ description: Aktuelle Beiträge und Artikel von Open Innovation City Bielefeld z
         </div>
         
         {% assign sorted_beitraege = site.beitraege | sort: 'date' | reverse %}
-        
+
         {% if sorted_beitraege.size > 0 %}
         <div class="projects-grid">
             {% for beitrag in sorted_beitraege %}
+            {% unless beitrag.is_retrospective %}
             <div class="project-card fade-in has-link">
                 {% if beitrag.category %}
                 <div class="project-tag">{{ beitrag.category }}</div>
@@ -82,6 +83,7 @@ description: Aktuelle Beiträge und Artikel von Open Innovation City Bielefeld z
                     </a>
                 </div>
             </div>
+            {% endunless %}
             {% endfor %}
         </div>
         {% else %}


### PR DESCRIPTION
Über das Frontmatter kann ein Rückblick mit einem bestehenden Beitrag verknüpft werden. So. wird vom bestehenden Event-Beitrag auf den Rückblick verwiesen, ohne den Ursprungsartikel verändern zu müssen.