### PR TITLE
Zitatmodul hinzugefügt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,38 @@ Use the gallery include for GitHub Pages compatibility:
 - Optimized spacing: Image margin adjusted to bring caption closer to image
 - Responsive design: Captions adapt to all screen sizes
 
+### Adding Quote Blocks
+**New as of October 2025:** For embedding styled quotes in blog posts:
+```markdown
+{% include quote.html
+   text="The quote text goes here."
+   author="Optional source or author name" %}
+```
+
+**Quote Block Component:**
+- **Reuses 404 page design**: Same styling as the Douglas Adams quote on the 404 error page
+- **Visual elements**: Large decorative quotation mark, white card with shadow, blue accent border
+- **Flexible layout**: Works with or without author attribution
+- **Responsive design**: Adapts to all screen sizes with mobile-optimized spacing
+
+**Parameters:**
+- `text`: Quote text (required)
+- `author`: Source/author attribution (optional) - displayed right-aligned below quote
+
+**Implementation Details:**
+- Component file: `_includes/quote.html`
+- Self-contained styling within component (no main.css dependencies)
+- CSS uses design token variables: `--primary-turquoise`, `--secondary-blue`, `--text-dark`, etc.
+- Responsive breakpoints at 768px and 480px
+- Font size scales from 1.3rem (desktop) to 1.1rem (mobile)
+
+**Example Usage:**
+```markdown
+{% include quote.html
+   text="Innovation unterscheidet zwischen einem Anführer und einem Verfolger."
+   author="Steve Jobs" %}
+```
+
 ### Adding Pretix Event Widgets
 For embedding event registration forms directly in blog posts:
 ```markdown

--- a/REDAKTIONSLEITFADEN.md
+++ b/REDAKTIONSLEITFADEN.md
@@ -398,6 +398,59 @@ Der Workshop findet im Innovation Office statt...
 - **Kompatibel mit Galerien:** Kann mit Bildergalerien kombiniert werden
 - **Mobile-optimiert:** Funktioniert einwandfrei auf allen Geräten
 
+## Zitate einbinden
+
+Du kannst stilvolle Zitate in Blog-Beiträge einbinden. Das Zitat wird in einer hervorgehobenen Box mit großem Anführungszeichen angezeigt.
+
+### Zitat-Syntax:
+```markdown
+{% include quote.html
+   text="Der Zitat-Text kommt hier rein."
+   author="Name des Urhebers" %}
+```
+
+**Parameter:**
+- `text`: **Pflichtfeld** - Der Text des Zitats
+- `author`: Optional - Name der Person oder Quelle (z.B. "Albert Einstein" oder "Frei nach Douglas Adams")
+
+### Praktisches Beispiel:
+```markdown
+---
+title: "Innovation und Kreativität"
+author: "Maria Schmidt"
+category: "Insights"
+date: 2025-10-20
+---
+
+## Die Kraft der Innovation
+
+Innovation beginnt oft mit einem einfachen Gedanken.
+
+{% include quote.html
+   text="Innovation unterscheidet zwischen einem Anführer und einem Verfolger."
+   author="Steve Jobs" %}
+
+In diesem Artikel schauen wir uns an, wie...
+```
+
+### Design-Features:
+- **Hervorgehobene Box:** Weißer Hintergrund mit Schatten und blauem Akzent
+- **Großes Anführungszeichen:** Türkisfarbenes dekoratives Element
+- **Kursiver Text:** Elegant formatierter Zitattext
+- **Quellenangabe:** Rechtsbündig unter dem Zitat (optional)
+- **Responsive:** Passt sich an alle Bildschirmgrößen an
+
+### Wichtige Hinweise:
+- **Anführungszeichen nicht nötig:** Das große dekorative Anführungszeichen wird automatisch hinzugefügt
+- **Längere Zitate:** Funktioniert auch für mehrzeilige Zitate
+- **Ohne Urheber:** Lasse `author` einfach weg, wenn die Quelle unbekannt ist
+
+**Beispiel ohne Urheber:**
+```markdown
+{% include quote.html
+   text="Die beste Zeit, einen Baum zu pflanzen, war vor 20 Jahren. Die zweitbeste Zeit ist jetzt." %}
+```
+
 ## YouTube-Videos einbetten
 
 Du kannst einfach YouTube-Videos in Blog-Beiträge einbinden. Das Video wird als interaktives Thumbnail angezeigt und lädt erst beim Klick.

--- a/_beitraege/open-innovation-city.md
+++ b/_beitraege/open-innovation-city.md
@@ -20,8 +20,11 @@ Wir reden auf Augenhöhe miteinander, wir Duzen. Kennst du vom schwedischen Möb
 
 ### Die Idee dahinter
 
-**Professor Henry Chesbrough**, der Vordenker des Open-Innovation-Prinzips, bringt es auf den Punkt: 
->„Mit einer offenen Denkweise und der effektiven Nutzung digitaler Technologien haben wir die Möglichkeit, mit Open Innovation Cities ein neues Kapitel zu schreiben.“
+**Professor Henry Chesbrough**, der Vordenker des Open-Innovation-Prinzips, bringt es auf den Punkt:
+
+{% include quote.html
+   text="Mit einer offenen Denkweise und der effektiven Nutzung digitaler Technologien haben wir die Möglichkeit, mit Open Innovation Cities ein neues Kapitel zu schreiben."
+   author="Professor Henry Chesbrough" %}
 
 Im Gegensatz zu geschlossenen Prozessen, bei denen Innovationen oft innerhalb einzelner Organisationen entstehen, fördert der Open-Innovation-Ansatz die bewusste Öffnung nach außen. Es geht darum, über die eigenen Grenzen hinauszuschauen, Know-how zu bündeln und so schneller und effektiver zu neuen Lösungen zu gelangen.
 ![Darstellung des Open Innovation City Funnels](/assets/images/OIC_Funnel_1920x1080.jpg "Open Innovation City Funnel")

--- a/_includes/quote.html
+++ b/_includes/quote.html
@@ -1,0 +1,80 @@
+<!-- Quote Component -->
+<div class="quote-block">
+    <blockquote>
+        <p>{{ include.text }}</p>
+        {% if include.author %}
+        <cite>{{ include.author }}</cite>
+        {% endif %}
+    </blockquote>
+</div>
+
+<style>
+/* Quote Block Component (reused from 404 page) */
+.quote-block {
+    margin: 3rem 0;
+    padding: 2rem;
+    background: var(--white);
+    border-radius: 20px;
+    box-shadow: var(--shadow-medium);
+    border-left: 5px solid var(--secondary-blue);
+    position: relative;
+}
+
+.quote-block::before {
+    content: '"';
+    font-size: 4rem;
+    color: var(--primary-turquoise);
+    position: absolute;
+    top: -1rem;
+    left: 1rem;
+    font-family: Georgia, serif;
+}
+
+/* Override default blockquote styles from post.html */
+.quote-block blockquote {
+    margin: 0 !important;
+    padding: 0 !important;
+    background: transparent !important;
+    border-left: none !important;
+    border-radius: 0 !important;
+}
+
+.quote-block blockquote p {
+    font-size: 1.3rem;
+    font-style: italic;
+    color: var(--text-dark);
+    margin-bottom: 1rem;
+    line-height: 1.4;
+}
+
+.quote-block cite {
+    display: block;
+    font-size: 0.9rem;
+    color: var(--text-light);
+    font-style: normal;
+    text-align: right;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .quote-block {
+        margin: 2rem 0;
+        padding: 1.5rem;
+    }
+
+    .quote-block blockquote p {
+        font-size: 1.1rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .quote-block {
+        padding: 1rem;
+    }
+
+    .quote-block::before {
+        font-size: 3rem;
+        top: -0.5rem;
+    }
+}
+</style>


### PR DESCRIPTION
Zitatmodul hinzugefügt, dass sich an der Darstellung auf unserer 404-Seite orientiert. Die Dokumentation dazu ist im Redaktionsleitfaden hinterlegt. Das Modul kann über ein `include` hinzugefügt werden. Dort muss dann nur das Zitat und die Autorin angegeben werden. Wird die Autorin nicht angegeben, entfällt die Darstellung der Autorin.

closes #46 