### PR TITLE
Nutzung der Gallery vereinfacht

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,19 +138,34 @@ For specialized event pages that show only events from a specific topic, use the
 
 ### Adding Image Galleries
 Use the gallery include for GitHub Pages compatibility:
+
+**Automatic mode (recommended for multiple images):**
 ```markdown
-{% include gallery.html 
-   images="image1.jpg|Optional caption 1,image2.jpg|Another caption,image3.jpg" 
+{% include gallery.html folder="/assets/images/folder/" %}
+```
+
+**Manual mode (for specific images with custom captions):**
+```markdown
+{% include gallery.html
+   images="image1.jpg|Optional caption 1,image2.jpg|Another caption,image3.jpg"
    folder="/assets/images/folder/" %}
 ```
 
 **Gallery Features:**
+- **Automatic folder loading** (new as of October 2025): Omit `images` parameter to load all images from folder
 - **Pinterest-style masonry layout** with responsive grid (5→3→2→1 columns)
 - **Enhanced lightbox** with arrow navigation and keyboard support (←/→ keys)
 - **Touch gestures** for mobile (swipe left/right to navigate)
 - **Image preloading** for smooth navigation experience
 - **Captions support** with `|` separator (auto-generated from filename if omitted)
 - **Progressive enhancement** - works without JavaScript for basic image display
+- **Gallery isolation**: Multiple galleries on same page are kept separate in lightbox navigation
+
+**Implementation Details:**
+- **Unique gallery IDs**: Gallery ID is generated from folder path to ensure separation between multiple galleries
+- **Automatic image detection**: Uses Jekyll's `site.static_files` to find all images (jpg, jpeg, png, gif, webp) in specified folder
+- **Alphabetical sorting**: Auto-loaded images are sorted alphabetically (use numerical prefixes for custom order: `01-first.jpg`, `02-second.jpg`)
+- **Manual override**: Use `gallery_id` parameter to explicitly set gallery ID if needed
 
 ### Adding Images with Captions in Blog Posts
 **New as of January 2025:** Images in blog posts now support automatic caption display using the title attribute:
@@ -429,3 +444,4 @@ This ensures clean category organization while keeping retrospectives accessible
 - **German language**: Content structure optimized for German municipal website requirements
 - **Legal compliance**: Includes proper Impressum/Datenschutz pages
 - **Asset optimization**: Images automatically compressed, CSS/JS minified on build
+- Always assume, that a Jekyll with Livereload ist running in the background for testing purposes.

--- a/REDAKTIONSLEITFADEN.md
+++ b/REDAKTIONSLEITFADEN.md
@@ -305,20 +305,41 @@ Passanten&shy;frequenz&shy;messung
 **Neu seit Januar 2025:** Du kannst jetzt einfach Bildergalerien in Blog-Beiträgen einbinden!
 
 ### Galerie-Syntax:
+
+**Option 1: Automatisch (alle Bilder aus Ordner)** ⭐ Empfohlen für viele Bilder
 ```markdown
-{% include gallery.html 
-   images="bild1.jpg|Beschreibung 1,bild2.jpg|Beschreibung 2,bild3.jpg" 
+{% include gallery.html folder="/assets/images/events/workshop-2025/" %}
+```
+
+**Option 2: Manuell (spezifische Bilder mit Beschreibungen)**
+```markdown
+{% include gallery.html
+   images="bild1.jpg|Beschreibung 1,bild2.jpg|Beschreibung 2,bild3.jpg"
    folder="/assets/images/events/workshop-2025/" %}
 ```
 
 **Parameter:**
-- `images`: Komma-getrennte Liste von Dateinamen mit optionalen Beschreibungen (getrennt durch `|`)
-- `folder`: Pfad zum Ordner mit den Bildern
+- `folder`: **Pflichtfeld** - Pfad zum Ordner mit den Bildern
+- `images`: Optional - Komma-getrennte Liste von Dateinamen mit optionalen Beschreibungen (getrennt durch `|`)
+
+### Automatischer Modus (neu seit Oktober 2025):
+Wenn du **nur den Ordner** angibst, werden automatisch **alle Bilder** aus diesem Ordner geladen:
+- ✅ **Einfacher:** Nur Ordner-Pfad angeben, fertig!
+- ✅ **Keine Liste:** Bildnamen müssen nicht aufgezählt werden
+- ✅ **Sortierung:** Bilder werden alphabetisch sortiert
+- 💡 **Tipp:** Nummeriere Dateien für gewünschte Reihenfolge: `01-eröffnung.jpg`, `02-workshop.jpg` etc.
+
+### Manueller Modus (klassisch):
+Wenn du **spezifische Bilder** auswählst oder **individuelle Beschreibungen** brauchst:
+- ✅ **Kontrolle:** Du bestimmst exakt, welche Bilder erscheinen
+- ✅ **Bildunterschriften:** Individuelle Beschreibungen mit `|` Trenner
+- ✅ **Reihenfolge:** Bilder erscheinen in der angegebenen Reihenfolge
 
 ### Wichtige Hinweise:
-- **Beschreibungen sind optional:** Mit `|` kannst du Bildunterschriften hinzufügen
+- **Bildunterschriften automatisch:** Ohne Beschreibungen werden Dateinamen als Caption genutzt (`workshop-raum.jpg` → "Workshop raum")
 - **Bilder hochladen:** Lade alle Bilder zuerst in `assets/images/` hoch
 - **Pfade kopieren:** Rechtsklick auf das Bild → "Link kopieren" für den korrekten Pfad
+- **Mehrere Galerien:** Du kannst mehrere Galerien auf einer Seite einbinden - jede wird separat in der Lightbox angezeigt
 
 ### Galerie-Features:
 - **Automatisches Layout:** Pinterest-ähnliche Anordnung der Thumbnails
@@ -327,13 +348,34 @@ Passanten&shy;frequenz&shy;messung
 - **Touch-Unterstützung:** Wischen zwischen Bildern auf Mobilgeräten
 
 ### Beispiel einer Event-Galerie:
+
+**Automatisch (alle Bilder aus Ordner):**
 ```markdown
 Hier sind Impressionen von unserem Workshop:
 
-{% include gallery.html 
-   images="eröffnung.jpg|Begrüßung der Teilnehmer*innen,gruppenarbeit.jpg|Intensive Diskussionen in Kleingruppen,präsentation.jpg|Vorstellung der Ergebnisse,networking.jpg" 
+{% include gallery.html folder="/assets/images/events/workshop-2025/" %}
+```
+
+**Manuell (mit individuellen Beschreibungen):**
+```markdown
+Hier sind Impressionen von unserem Workshop:
+
+{% include gallery.html
+   images="eröffnung.jpg|Begrüßung der Teilnehmer*innen,gruppenarbeit.jpg|Intensive Diskussionen in Kleingruppen,präsentation.jpg|Vorstellung der Ergebnisse,networking.jpg"
    folder="/assets/images/events/workshop-2025/" %}
 ```
+
+**Mehrere Galerien auf einer Seite:**
+```markdown
+## Vormittagssession
+
+{% include gallery.html folder="/assets/images/events/workshop-2025/vormittag/" %}
+
+## Nachmittagssession
+
+{% include gallery.html folder="/assets/images/events/workshop-2025/nachmittag/" %}
+```
+👉 Jede Galerie wird in der Lightbox separat behandelt - keine Vermischung!
 
 ## Event-Anmeldungen einbinden (Pretix-Widgets)
 

--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -1,39 +1,67 @@
 {% comment %}
-Gallery Include for GitHub Pages compatibility
-Usage: {% include gallery.html images="image1.jpg|Caption 1,image2.jpg|Caption 2,image3.jpg" folder="/assets/images/events/workshop/" %}
+Gallery Include with automatic folder loading
+Usage:
+  Manual: {% include gallery.html images="img1.jpg|Caption,img2.jpg" folder="/assets/images/event/" %}
+  Auto:   {% include gallery.html folder="/assets/images/event/" %}
 {% endcomment %}
 
 {% assign gallery_id = include.gallery_id | default: 'gallery' %}
 {% unless include.gallery_id %}
-  {% assign random_num = page.url | size | times: include.images | size %}
-  {% assign gallery_id = 'gallery-' | append: random_num %}
+  {% comment %} Generate unique gallery ID using folder path and timestamp-like value {% endcomment %}
+  {% assign folder_hash = include.folder | default: '/assets/images/' | remove: '/' | remove: '.' %}
+  {% assign images_hash = include.images | default: 'auto' | size %}
+  {% assign random_num = page.url | size | times: images_hash | times: 997 | plus: folder_hash | size %}
+  {% assign gallery_id = 'gallery-' | append: folder_hash | append: '-' | append: random_num %}
 {% endunless %}
 {% assign folder = include.folder | default: '/assets/images/' %}
-{% assign images_raw = include.images | split: ',' %}
+
+{% if include.images %}
+  {% comment %} OLD BEHAVIOR: Manual image list {% endcomment %}
+  {% assign images_raw = include.images | split: ',' %}
+  {% assign image_mode = 'manual' %}
+{% else %}
+  {% comment %} NEW BEHAVIOR: Auto-load all images from folder {% endcomment %}
+  {% assign image_extensions = ".jpg,.jpeg,.png,.gif,.webp,.JPG,.JPEG,.PNG,.GIF,.WEBP" | split: "," %}
+  {% assign auto_images = "" | split: "" %}
+
+  {% for file in site.static_files %}
+    {% if file.path contains folder %}
+      {% if image_extensions contains file.extname %}
+        {% assign auto_images = auto_images | push: file.path %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+
+  {% assign images_raw = auto_images | sort %}
+  {% assign image_mode = 'auto' %}
+{% endif %}
 
 <div class="image-gallery" data-gallery-id="{{ gallery_id }}">
   {% for image_raw in images_raw %}
-    {% assign image_parts = image_raw | split: '|' %}
-    {% assign image_path = image_parts[0] | strip %}
-    {% assign image_caption = image_parts[1] | strip | default: '' %}
-    
-    {% comment %} Generate alt text from filename if no caption {% endcomment %}
+    {% if image_mode == 'manual' %}
+      {% assign image_parts = image_raw | split: '|' %}
+      {% assign image_path = image_parts[0] | strip %}
+      {% assign image_caption = image_parts[1] | strip | default: '' %}
+
+      {% unless image_path contains '/' %}
+        {% assign image_path = folder | append: image_path %}
+      {% endunless %}
+    {% else %}
+      {% assign image_path = image_raw %}
+      {% assign image_caption = '' %}
+    {% endif %}
+
     {% if image_caption == '' %}
       {% assign filename = image_path | split: '/' | last | split: '.' | first %}
       {% assign image_caption = filename | replace: '-', ' ' | replace: '_', ' ' | capitalize %}
     {% endif %}
-    
-    {% comment %} Add folder path if not absolute {% endcomment %}
-    {% unless image_path contains '/' %}
-      {% assign image_path = folder | append: image_path %}
-    {% endunless %}
-    
+
     <div class="gallery-item" data-index="{{ forloop.index0 }}">
-      <img src="{{ image_path }}" 
-           alt="{{ image_caption }}" 
-           data-caption="{{ image_caption }}" 
-           data-gallery="{{ gallery_id }}" 
-           loading="lazy" 
+      <img src="{{ image_path }}"
+           alt="{{ image_caption }}"
+           data-caption="{{ image_caption }}"
+           data-gallery="{{ gallery_id }}"
+           loading="lazy"
            class="gallery-thumbnail">
       <div class="gallery-overlay"></div>
     </div>


### PR DESCRIPTION
Bei der Einbindung der Gallery brauchen keine Einzelbilder mehr angegeben werden. Es reicht jetzt, nur den Ordner der Bilder anzugeben.

Das alte Verhalten bleibt erhalten, es können also auch die Einzelbilder angegeben werden, wenn man eine bestimmte Reihenfolge benötigt.

closes #25 