### PR TITLE
Masonry-Layout der Gallerie korrigiert

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1819,14 +1819,15 @@ body:has(.event-alert-banner) .navbar {
 /* Fallback for browsers without masonry support */
 @supports not (grid-template-rows: masonry) {
   .image-gallery {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-start;
+    display: block;
+    column-count: 3;
+    column-gap: 1rem;
   }
-  
+
   .gallery-item {
-    flex: 1 1 calc(20% - 1rem);
-    min-width: 200px;
+    display: inline-block;
+    width: 100%;
+    break-inside: avoid;
     margin-bottom: 1rem;
   }
 }
@@ -2008,11 +2009,10 @@ body:has(.event-alert-banner) .navbar {
   .image-gallery {
     grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   }
-  
+
   @supports not (grid-template-rows: masonry) {
-    .gallery-item {
-      flex: 1 1 calc(25% - 1rem);
-      min-width: 180px;
+    .image-gallery {
+      column-count: 3;
     }
   }
 }
@@ -2023,11 +2023,11 @@ body:has(.event-alert-banner) .navbar {
     gap: 0.75rem;
     padding: 0.75rem;
   }
-  
+
   @supports not (grid-template-rows: masonry) {
-    .gallery-item {
-      flex: 1 1 calc(33.333% - 0.75rem);
-      min-width: 150px;
+    .image-gallery {
+      column-count: 2;
+      column-gap: 0.75rem;
     }
   }
   
@@ -2066,11 +2066,11 @@ body:has(.event-alert-banner) .navbar {
     padding: 0.5rem;
     margin: 1rem 0;
   }
-  
+
   @supports not (grid-template-rows: masonry) {
-    .gallery-item {
-      flex: 1 1 calc(50% - 0.5rem);
-      min-width: 120px;
+    .image-gallery {
+      column-count: 1;
+      column-gap: 0.5rem;
     }
   }
   


### PR DESCRIPTION
Die Bilder aus Bildergallerien werden jetzt im korrekten Masonry-Layout dargestellt, sodass keine Lücken entstehen (angelehnt an Pinterest)