### PR TITLE
Öffnen des Newsletter-Modals per URL hinzugefügt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Single CSS file (`assets/css/main.css`) with **design token system**:
 ### JavaScript Interactions
 Class-based architecture (`assets/js/main.js`) with:
 - **AdaptiveNavigation class** for automatic theme switching via background color detection
+- **NewsletterModal class** for newsletter overlay with URL-based auto-opening (`?newsletter=true` or `#newsletter`)
 - **Intersection Observer API** for scroll-triggered animations with staggered delays
 - **Error-resilient asset loading** with logo fallback system
 - **Performance-optimized animations** using requestAnimationFrame
@@ -432,6 +433,38 @@ The filter system **automatically excludes** retrospective posts (marked with `i
 - "Alle" button count
 
 This ensures clean category organization while keeping retrospectives accessible via linked announcements.
+
+### Newsletter Direct Links
+
+**New as of November 2025:** The newsletter modal can be opened directly via URL parameters or hash fragments.
+
+**Use Cases:**
+- Email campaigns linking directly to newsletter signup
+- Social media posts with direct registration
+- QR codes at events
+- External marketing materials
+
+**URL Formats:**
+- **URL Parameter** (recommended): `?newsletter=true`
+  - Example: `https://oic-bielefeld.de/?newsletter=true`
+  - Example: `https://oic-bielefeld.de/beitraege/?newsletter=true`
+
+- **Hash Fragment**: `#newsletter`
+  - Example: `https://oic-bielefeld.de/#newsletter`
+  - Example: `https://oic-bielefeld.de/events/#newsletter`
+
+**Implementation Details:**
+- JavaScript class: `NewsletterModal` in `assets/js/main.js:948-1002`
+- Method: `checkURLForAutoOpen()` (line 979-991)
+- Auto-opens modal on page load when URL contains parameter/hash
+- Compatible with all existing modal functionality (ESC key, overlay click, close button)
+- Works on all pages where the newsletter modal is present
+
+**Technical Notes:**
+- Uses `URLSearchParams` API for parameter detection
+- Hash detection via `window.location.hash`
+- Modal opens automatically after DOM ready
+- No interference with regular modal triggers
 
 ### Styling Considerations
 - **Background color detection**: Navigation automatically adapts to section backgrounds

--- a/REDAKTIONSLEITFADEN.md
+++ b/REDAKTIONSLEITFADEN.md
@@ -545,6 +545,68 @@ Im Workshop haben wir verschiedene KI-Tools vorgestellt...
 
 **Ausführliche Referenz:** [Markdown Cheat Sheet](https://www.markdownguide.org/cheat-sheet/)
 
+## Newsletter-Anmeldung per Link
+
+**Neu seit November 2025:** Du kannst jetzt direkte Links zur Newsletter-Anmeldung erstellen!
+
+### Wofür ist das nützlich?
+
+Mit direkten Newsletter-Links kannst du:
+- **E-Mails versenden** mit direktem Link zur Anmeldung
+- **Social Media Posts** erstellen, die direkt zur Anmeldung führen
+- **QR-Codes** für Events generieren
+- **Externe Kampagnen** starten
+
+### Link-Formate:
+
+**Option 1: URL-Parameter** ⭐ Empfohlen für E-Mails
+```
+https://oic-bielefeld.de/?newsletter=true
+https://oic-bielefeld.de/beitraege/?newsletter=true
+https://oic-bielefeld.de/events/?newsletter=true
+```
+
+**Option 2: Hash-Fragment** (kürzer)
+```
+https://oic-bielefeld.de/#newsletter
+https://oic-bielefeld.de/events/#newsletter
+```
+
+### Was passiert?
+
+Wenn jemand auf einen dieser Links klickt:
+1. Die Website öffnet sich normal
+2. Das Newsletter-Anmeldeformular erscheint automatisch als Overlay
+3. Die Person kann sich direkt anmelden
+4. Das Overlay lässt sich mit ESC oder durch Klick außerhalb schließen
+
+### Praktisches Beispiel für E-Mail:
+
+```
+Liebe Interessierte,
+
+bleiben Sie auf dem Laufenden über unsere neuesten Events und Projekte!
+
+👉 Jetzt zum Newsletter anmelden: https://oic-bielefeld.de/?newsletter=true
+
+Viele Grüße
+Ihr OIC Team
+```
+
+### Wichtige Hinweise:
+
+- ✅ **Funktioniert auf allen Seiten** der Website
+- ✅ **Kombination möglich** mit bestehenden Links (z.B. `/events/?newsletter=true`)
+- ✅ **Keine zusätzliche Konfiguration** nötig
+- ✅ **Mobile-optimiert** funktioniert auf allen Geräten
+
+### QR-Code erstellen:
+
+1. Gehe zu einem QR-Code-Generator (z.B. [qr-code-generator.com](https://www.qr-code-generator.com/))
+2. Gib die URL ein: `https://oic-bielefeld.de/?newsletter=true`
+3. Generiere und lade den QR-Code herunter
+4. Verwende ihn auf Flyern, Präsentationen oder Veranstaltungen
+
 ## Bilder hochladen
 
 **Verzeichnis:** `assets/images/`

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -971,6 +971,23 @@
                     this.close();
                 }
             });
+
+            // Check URL for automatic opening
+            this.checkURLForAutoOpen();
+        }
+
+        checkURLForAutoOpen() {
+            // Check for URL parameter ?newsletter=true
+            const urlParams = new URLSearchParams(window.location.search);
+            if (urlParams.get('newsletter') === 'true') {
+                this.open();
+                return;
+            }
+
+            // Check for hash #newsletter
+            if (window.location.hash === '#newsletter') {
+                this.open();
+            }
         }
 
         open() {


### PR DESCRIPTION
Öffnen über http://loic-bielefeld.de/?newsletter=true oder http://loic-bielefeld.de/#newsletter